### PR TITLE
No Integer match operation

### DIFF
--- a/lib/openxml/drawingml/properties/percentage_property.rb
+++ b/lib/openxml/drawingml/properties/percentage_property.rb
@@ -4,7 +4,7 @@ module OpenXml
       class PercentageProperty < ValueProperty
 
         def valid?
-          value =~ OpenXml::DrawingML::ST_Percentage
+          value.is_a?(String) && value =~ OpenXml::DrawingML::ST_Percentage
         end
 
         def invalid_message

--- a/lib/openxml/drawingml/properties/space_after.rb
+++ b/lib/openxml/drawingml/properties/space_after.rb
@@ -12,7 +12,7 @@ module OpenXml
 
         def initialize(value)
           super()
-          target_property = value =~ /%/ ? :spacing_percent= : :spacing_points=
+          target_property = value.is_a?(String) && value =~ /%/ ? :spacing_percent= : :spacing_points=
           public_send(target_property, value)
         end
 

--- a/lib/openxml/drawingml/properties/space_before.rb
+++ b/lib/openxml/drawingml/properties/space_before.rb
@@ -12,7 +12,7 @@ module OpenXml
 
         def initialize(value)
           super()
-          target_property = value =~ /%/ ? :spacing_percent= : :spacing_points=
+          target_property = value.is_a?(String) && value =~ /%/ ? :spacing_percent= : :spacing_points=
           public_send(target_property, value)
         end
 

--- a/lib/openxml/drawingml/version.rb
+++ b/lib/openxml/drawingml/version.rb
@@ -1,5 +1,5 @@
 module OpenXml
   module DrawingML
-    VERSION = "0.3.0"
+    VERSION = "0.3.1"
   end
 end


### PR DESCRIPTION
I think older versions of Ruby were less strict, but newer versions complain about `Integer` not responding to `~=`, so we'll only proceed with that check if we're sure the value we're validating is a `String`